### PR TITLE
Change renderers to check for parts instead of content type

### DIFF
--- a/lib/rails_mail/renderer/html_renderer.rb
+++ b/lib/rails_mail/renderer/html_renderer.rb
@@ -2,8 +2,7 @@ module RailsMail
   module Renderer
     class HtmlRenderer < Base
       def self.handles?(email)
-        email.content_type&.include?("text/html") ||
-          email.content_type&.include?("multipart/alternative")
+        email.html_part.present?
       end
 
       def self.partial_name

--- a/lib/rails_mail/renderer/text_renderer.rb
+++ b/lib/rails_mail/renderer/text_renderer.rb
@@ -2,8 +2,7 @@ module RailsMail
   module Renderer
     class TextRenderer < Base
       def self.handles?(email)
-        email.content_type&.include?("text/plain") ||
-          email.content_type&.include?("multipart/alternative")
+        email.text_part.present?
       end
 
       def self.partial_name


### PR DESCRIPTION
Hello,

First of all, thank you for this gem I just discovered!

I encountered an issue with an email that includes an attachment and has a `multipart/mixed` content type. This type isn’t recognized by the renderers, so the HTML part isn’t displayed.

I modified the renderers to check for the presence of an `html_part` or `text_part` instead of relying on the content type.

I’m not entirely sure of the broader impact, but it seems more flexible.
